### PR TITLE
Adjust the sidebar when national collections are selected

### DIFF
--- a/src/Page/SideBar/Views.elm
+++ b/src/Page/SideBar/Views.elm
@@ -160,6 +160,7 @@ view session =
 
         currentlySelectedOption =
             session.showFrontSearchInterface
+
         restrictedToNationalCollection =
             case session.restrictedToNationalCollection of
                 Just _ ->


### PR DESCRIPTION
When a national collection is selected we should not show the `people` and the `incipits` tabs because these are not meant to be searched with a national collection filter.

The PR tries to adjust the sidebar when a national collection is selected by hiding the `people` and the `incipits` tabs in the sidebar. A new `hidden` member was added to the `menuOption` to carry the flag indicating if the national collection filter is activated of not (namely indicating if the tabs is hidden or not)