### PR TITLE
HOTFIX: Scrolling broken on latest chrome

### DIFF
--- a/src/Page/About/Views/About.elm
+++ b/src/Page/About/Views/About.elm
@@ -1,9 +1,10 @@
 module Page.About.Views.About exposing (view)
 
 import Config as C
-import Element exposing (Element, clipY, column, el, fill, height, maximum, none, padding, row, scrollbarY, spacing, text, width)
+import Element exposing (Element, clipY, column, el, fill, height, htmlAttribute, maximum, none, padding, row, scrollbarY, spacing, text, width)
 import Element.Background as Background
 import Element.Font as Font
+import Html.Attributes as HA
 import Language exposing (Language(..), LanguageMap, LanguageValue(..))
 import Page.About.Model exposing (AboutPageModel)
 import Page.About.Msg exposing (AboutMsg)
@@ -67,6 +68,7 @@ view session model =
             , Background.color colourScheme.white
             , spacing sectionSpacing
             , scrollbarY
+            , htmlAttribute (HA.style "min-height" "unset")
             ]
             [ row
                 [ width (fill |> maximum 900)

--- a/src/Page/About/Views/Help.elm
+++ b/src/Page/About/Views/Help.elm
@@ -1,8 +1,9 @@
 module Page.About.Views.Help exposing (IconDescriptionData, view)
 
-import Element exposing (Color, Element, centerY, clipY, column, el, fill, height, maximum, padding, paragraph, px, row, scrollbarY, shrink, spacing, table, text, width)
+import Element exposing (Color, Element, centerY, clipY, column, el, fill, height, htmlAttribute, maximum, padding, paragraph, px, row, scrollbarY, shrink, spacing, table, text, width)
 import Element.Background as Background
 import Element.Font as Font
+import Html.Attributes as HA
 import Language exposing (Language(..), LanguageMap, LanguageValue(..), extractLabelFromLanguageMap, toLanguageMapWithLanguage)
 import Page.UI.Attributes exposing (sectionSpacing)
 import Page.UI.DiammLogo exposing (diammLogo)
@@ -498,6 +499,7 @@ view session =
             , spacing sectionSpacing
             , Font.size 16
             , scrollbarY
+            , htmlAttribute (HA.style "min-height" "unset")
             ]
             [ row
                 [ width (fill |> maximum 900)

--- a/src/Page/About/Views/Options.elm
+++ b/src/Page/About/Views/Options.elm
@@ -1,8 +1,9 @@
 module Page.About.Views.Options exposing (view)
 
-import Element exposing (Element, clipY, column, el, fill, height, maximum, padding, paragraph, row, scrollbarY, spacing, text, textColumn, width)
+import Element exposing (Element, clipY, column, el, fill, height, htmlAttribute, maximum, padding, paragraph, row, scrollbarY, spacing, text, textColumn, width)
 import Element.Background as Background
 import Element.Font as Font
+import Html.Attributes as HA
 import Language exposing (Language(..), LanguageMap, LanguageValue(..), extractLabelFromLanguageMap)
 import Page.About.Model exposing (AboutPageModel)
 import Page.About.Msg exposing (AboutMsg(..))
@@ -80,6 +81,7 @@ view session model =
             , Background.color colourScheme.white
             , spacing sectionSpacing
             , scrollbarY
+            , htmlAttribute (HA.style "min-height" "unset")
             ]
             [ row
                 [ width fill ]

--- a/src/Page/Record/Views/InstitutionPage/FullRecordPage.elm
+++ b/src/Page/Record/Views/InstitutionPage/FullRecordPage.elm
@@ -1,7 +1,8 @@
 module Page.Record.Views.InstitutionPage.FullRecordPage exposing (viewFullInstitutionPage)
 
-import Element exposing (Element, alignLeft, alignTop, centerX, centerY, column, el, fill, height, padding, paddingXY, paragraph, px, row, scrollbarY, spacing, text, textColumn, width, wrappedRow)
+import Element exposing (Element, alignLeft, alignTop, centerX, centerY, column, el, fill, height, htmlAttribute, padding, paddingXY, paragraph, px, row, scrollbarY, spacing, text, textColumn, width, wrappedRow)
 import Element.Border as Border
+import Html.Attributes as HA
 import Language exposing (Language, extractLabelFromLanguageMap)
 import Language.LocalTranslations exposing (localTranslations)
 import Page.Record.Model exposing (CurrentRecordViewTab(..), RecordPageModel)
@@ -32,6 +33,7 @@ viewDescriptionTab language ( windowWidth, windowHeight ) body =
         , height fill
         , alignTop
         , scrollbarY
+        , htmlAttribute (HA.style "min-height" "unset")
         ]
         [ column
             [ width fill

--- a/src/Page/Record/Views/SourcePage/FullRecordPage.elm
+++ b/src/Page/Record/Views/SourcePage/FullRecordPage.elm
@@ -1,8 +1,9 @@
 module Page.Record.Views.SourcePage.FullRecordPage exposing (viewFullSourcePage)
 
 import Dict
-import Element exposing (Element, alignLeft, alignTop, centerY, column, el, fill, height, padding, paddingXY, px, row, scrollbarY, spacing, width)
+import Element exposing (Element, alignLeft, alignTop, centerY, column, el, fill, height, htmlAttribute, padding, paddingXY, px, row, scrollbarY, spacing, width)
 import Element.Border as Border
+import Html.Attributes as HA
 import Language exposing (Language)
 import Language.LocalTranslations exposing (localTranslations)
 import Page.Record.Model exposing (CurrentRecordViewTab(..), RecordPageModel)
@@ -136,6 +137,7 @@ viewDescriptionTab { expandedDigitizedCopiesCallout, expandedDigitizedCopiesMsg,
         , height fill
         , alignTop
         , scrollbarY
+        , htmlAttribute (HA.style "min-height" "unset")
         ]
         [ column
             [ width fill

--- a/src/Page/SideBar/Views/NationalCollectionChooser.elm
+++ b/src/Page/SideBar/Views/NationalCollectionChooser.elm
@@ -148,6 +148,7 @@ viewNationalCollectionChooser session =
                 , spacing sectionSpacing
                 , padding 30
                 , scrollbarY
+                , htmlAttribute (HA.style "min-height" "unset")
                 ]
                 [ row
                     [ width fill ]

--- a/src/Page/UI/Record/Previews.elm
+++ b/src/Page/UI/Record/Previews.elm
@@ -83,6 +83,7 @@ viewPreviewError cfg =
                 [ width fill
                 , height fill
                 , scrollbarY
+                , htmlAttribute (HA.style "min-height" "unset")
                 ]
                 [ paragraph
                     [ centerX

--- a/src/Page/UI/Record/Previews/ExternalInstitution.elm
+++ b/src/Page/UI/Record/Previews/ExternalInstitution.elm
@@ -1,6 +1,7 @@
 module Page.UI.Record.Previews.ExternalInstitution exposing (viewExternalInstitutionPreview)
 
-import Element exposing (Element, alignRight, alignTop, centerY, column, el, fill, fillPortion, height, inFront, none, paddingXY, px, row, scrollbarY, spacing, width)
+import Element exposing (Element, alignRight, alignTop, centerY, column, el, fill, fillPortion, height, htmlAttribute, inFront, none, paddingXY, px, row, scrollbarY, spacing, width)
+import Html.Attributes as HA
 import Language exposing (Language)
 import Page.RecordTypes.ExternalRecord exposing (ExternalInstitutionRecord, ExternalProject(..))
 import Page.UI.Attributes exposing (lineSpacing, sectionSpacing)
@@ -56,6 +57,7 @@ viewExternalInstitutionPreview language project body =
         , alignTop
         , paddingXY 20 10
         , scrollbarY
+        , htmlAttribute (HA.style "min-height" "unset")
         ]
         [ column
             [ width fill

--- a/src/Page/UI/Record/Previews/ExternalPerson.elm
+++ b/src/Page/UI/Record/Previews/ExternalPerson.elm
@@ -1,6 +1,7 @@
 module Page.UI.Record.Previews.ExternalPerson exposing (viewExternalPersonPreview)
 
-import Element exposing (Element, alignRight, alignTop, centerY, column, el, fill, fillPortion, height, inFront, none, paddingXY, px, row, scrollbarY, spacing, width)
+import Element exposing (Element, alignRight, alignTop, centerY, column, el, fill, fillPortion, height, htmlAttribute, inFront, none, paddingXY, px, row, scrollbarY, spacing, width)
+import Html.Attributes as HA
 import Language exposing (Language)
 import Page.RecordTypes.ExternalRecord exposing (ExternalPersonRecord, ExternalProject(..))
 import Page.UI.Attributes exposing (lineSpacing, sectionSpacing)
@@ -56,6 +57,7 @@ viewExternalPersonPreview language project body =
         , alignTop
         , paddingXY 20 10
         , scrollbarY
+        , htmlAttribute (HA.style "min-height" "unset")
         ]
         [ column
             [ width fill

--- a/src/Page/UI/Record/Previews/ExternalSource.elm
+++ b/src/Page/UI/Record/Previews/ExternalSource.elm
@@ -1,6 +1,7 @@
 module Page.UI.Record.Previews.ExternalSource exposing (viewExternalSourcePreview)
 
-import Element exposing (Element, above, alignLeft, alignRight, alignTop, centerY, column, el, fill, fillPortion, height, inFront, link, none, paddingXY, px, row, scrollbarY, spacing, text, textColumn, width, wrappedRow)
+import Element exposing (Element, above, alignLeft, alignRight, alignTop, centerY, column, el, fill, fillPortion, height, htmlAttribute, inFront, link, none, paddingXY, px, row, scrollbarY, spacing, text, textColumn, width, wrappedRow)
+import Html.Attributes as HA
 import Language exposing (Language, extractLabelFromLanguageMap)
 import Language.LocalTranslations exposing (localTranslations)
 import Page.RecordTypes.ExternalRecord exposing (ExternalInstitutionRecord, ExternalProject(..), ExternalSourceContents, ExternalSourceExemplar, ExternalSourceExemplarsSection, ExternalSourceExternalResource, ExternalSourceExternalResourcesSection, ExternalSourceRecord, ExternalSourceReferencesNotesSection)
@@ -60,6 +61,7 @@ viewExternalSourcePreview language project body =
         , alignTop
         , paddingXY 20 10
         , scrollbarY
+        , htmlAttribute (HA.style "min-height" "unset")
         ]
         [ column
             [ width fill

--- a/src/Page/UI/Record/Previews/Incipit.elm
+++ b/src/Page/UI/Record/Previews/Incipit.elm
@@ -1,6 +1,7 @@
 module Page.UI.Record.Previews.Incipit exposing (viewIncipitPreview)
 
-import Element exposing (Element, alignTop, centerY, column, el, fill, height, paddingXY, px, row, scrollbarY, spacing, width)
+import Element exposing (Element, alignTop, centerY, column, el, fill, height, htmlAttribute, paddingXY, px, row, scrollbarY, spacing, width)
+import Html.Attributes as HA
 import Language exposing (Language)
 import Page.RecordTypes.Incipit exposing (IncipitBody)
 import Page.UI.Attributes exposing (headingLG, lineSpacing, sectionSpacing)
@@ -44,6 +45,7 @@ viewIncipitPreview cfg body =
         , alignTop
         , paddingXY 20 10
         , scrollbarY
+        , htmlAttribute (HA.style "min-height" "unset")
         ]
         [ column
             [ spacing sectionSpacing

--- a/src/Page/UI/Record/Previews/Institution.elm
+++ b/src/Page/UI/Record/Previews/Institution.elm
@@ -1,6 +1,7 @@
 module Page.UI.Record.Previews.Institution exposing (viewInstitutionPreview)
 
-import Element exposing (Element, alignTop, centerY, column, el, fill, height, paddingXY, px, row, scrollbarY, spacing, width)
+import Element exposing (Element, alignTop, centerY, column, el, fill, height, htmlAttribute, paddingXY, px, row, scrollbarY, spacing, width)
+import Html.Attributes as HA
 import Language exposing (Language)
 import Page.Record.Views.InstitutionPage.LocationSection exposing (viewLocationAddressSection)
 import Page.RecordTypes.Institution exposing (InstitutionBody)
@@ -33,6 +34,7 @@ viewInstitutionPreview language body =
         , alignTop
         , paddingXY 20 10
         , scrollbarY
+        , htmlAttribute (HA.style "min-height" "unset")
         ]
         [ column
             [ width fill

--- a/src/Page/UI/Record/Previews/Person.elm
+++ b/src/Page/UI/Record/Previews/Person.elm
@@ -1,6 +1,7 @@
 module Page.UI.Record.Previews.Person exposing (viewPersonPreview)
 
-import Element exposing (Element, alignTop, centerY, column, el, fill, height, paddingXY, px, row, scrollbarY, spacing, width)
+import Element exposing (Element, alignTop, centerY, column, el, fill, height, htmlAttribute, paddingXY, px, row, scrollbarY, spacing, width)
+import Html.Attributes as HA
 import Language exposing (Language)
 import Page.RecordTypes.Person exposing (PersonBody)
 import Page.UI.Attributes exposing (lineSpacing, sectionSpacing)
@@ -32,6 +33,7 @@ viewPersonPreview language body =
         , alignTop
         , paddingXY 20 10
         , scrollbarY
+        , htmlAttribute (HA.style "min-height" "unset")
         ]
         [ column
             [ width fill

--- a/src/Page/UI/Record/Previews/Source.elm
+++ b/src/Page/UI/Record/Previews/Source.elm
@@ -1,7 +1,8 @@
 module Page.UI.Record.Previews.Source exposing (viewSourcePreview)
 
 import Dict
-import Element exposing (Element, alignTop, centerY, column, el, fill, height, paddingXY, px, row, scrollbarY, spacing, width)
+import Element exposing (Element, alignTop, centerY, column, el, fill, height, htmlAttribute, paddingXY, px, row, scrollbarY, spacing, width)
+import Html.Attributes as HA
 import Language exposing (Language)
 import Page.RecordTypes.Source exposing (FullSourceBody)
 import Page.UI.Attributes exposing (lineSpacing, sectionSpacing)
@@ -92,6 +93,7 @@ viewSourcePreview cfg body =
         , alignTop
         , paddingXY 20 10
         , scrollbarY
+        , htmlAttribute (HA.style "min-height" "unset")
         ]
         [ column
             [ width fill

--- a/src/Page/UI/Search/SearchView.elm
+++ b/src/Page/UI/Search/SearchView.elm
@@ -365,6 +365,7 @@ viewSearchControls cfg =
         , height fill
         , alignTop
         , scrollbarY
+        , htmlAttribute (HA.style "min-height" "unset")
         ]
         [ column
             [ width (fill |> maximum 1100)
@@ -415,6 +416,7 @@ viewSearchResultsListPanel cfg =
             , height fill
             , alignTop
             , scrollbarY
+            , htmlAttribute (HA.style "min-height" "unset")
             , htmlAttribute (HA.id "search-results-list")
             ]
             [ column

--- a/src/Page/UI/Search/Templates/SearchTmpl.elm
+++ b/src/Page/UI/Search/Templates/SearchTmpl.elm
@@ -49,6 +49,7 @@ viewSearchResultsLoadingTmpl language =
             , height fill
             , Background.color colourScheme.white
             , scrollbarY
+            , htmlAttribute (HA.style "min-height" "unset")
             , alignTop
             ]
             []


### PR DESCRIPTION
The latest version of Chrome breaks the scrolling of div elements. This hotfix applies the workaround in mdgriffith/elm-ui#367